### PR TITLE
Implement hero attack selection and cancel

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -134,6 +134,15 @@ export default class Battle {
     this._loadPathAssets();
   }
 
+  heroAttack(hero, enemy) {
+    if (!hero || !enemy || enemy.health <= 0) return;
+    const dist = Math.abs(hero.col - enemy.col) + Math.abs(hero.row - enemy.row);
+    if (dist > hero.attackRange) return;
+    enemy.health -= hero.attack;
+    if (enemy.health < 0) enemy.health = 0;
+    hero.actionTaken = true;
+  }
+
   _loadPathAssets() {
     // Load sekali, self-contained
     this.pathAssets = {

--- a/js/game.js
+++ b/js/game.js
@@ -98,11 +98,13 @@ export default class Game {
       window.gameOverlayActive = false;
       // Reset attack mode ketika giliran hero dimulai
       this.attackMode = false;
+      this.attackType = null;
     }, 3000);
 
     this.enemyTurnProcessing = false;
     this.currentEnemyIndex = 0;
     this.attackMode = false; // Flag attack mode
+    this.attackType = null;  // 'physical' atau 'magic'
   }
 
   isCellOccupied(col, row) {

--- a/js/input.js
+++ b/js/input.js
@@ -70,7 +70,7 @@ export function handleInput(game) {
 
   // Pointer up
   game.canvas.addEventListener('pointerup', (e) => {
-    // Jika mode attack aktif, cek apakah klik berada di dalam area overlay attack range.
+    // Jika mode attack aktif, proses pemilihan target atau cancel.
     if (game.attackMode && game.battle.selectedHero) {
       const hero = game.battle.selectedHero;
       const tileSize = game.grid.tileSize;
@@ -89,6 +89,7 @@ export function handleInput(game) {
       // Jika klik di luar area attack overlay, cancel attack mode.
       if (clickX < minX || clickX > maxX || clickY < minY || clickY > maxY) {
         game.attackMode = false;
+        game.attackType = null;
         const confirmMenu = document.getElementById('confirmMenu');
         confirmMenu.style.display = 'none';
         updateProfileStatus(null);
@@ -97,7 +98,27 @@ export function handleInput(game) {
         hasMoved = false;
         return;
       }
-      // Jika klik di dalam area, jangan memproses seleksi lagi.
+      // Jika klik di dalam area, cek apakah mengenai enemy
+      const col = Math.floor((clickX + game.camera.x) / tileSize);
+      const row = Math.floor((clickY + game.camera.y) / tileSize);
+      const enemy = getEnemyAtCell(col, row);
+      if (enemy && Math.abs(hero.col - enemy.col) + Math.abs(hero.row - enemy.row) <= hero.attackRange) {
+        game.battle.heroAttack(hero, enemy);
+        const actionMenu = document.getElementById('actionMenu');
+        const confirmMenu = document.getElementById('confirmMenu');
+        actionMenu.style.display = 'none';
+        confirmMenu.style.display = 'none';
+        game.attackMode = false;
+        game.attackType = null;
+        game.battle.selectedHero = null;
+        game.battle.actionMode = 'normal';
+        updateProfileStatus(null);
+        game.canvas.releasePointerCapture(e.pointerId);
+        isDragging = false;
+        hasMoved = false;
+        return;
+      }
+      // Klik di area kosong dalam overlay
       game.canvas.releasePointerCapture(e.pointerId);
       isDragging = false;
       hasMoved = false;

--- a/js/ui.js
+++ b/js/ui.js
@@ -59,6 +59,7 @@ export function setupActionMenu(game) {
       }
       // Masuk attack mode
       game.attackMode = true;
+      game.attackType = 'physical';
       game.battle.actionMode = 'selected';
       actionMenu.style.display = 'none';
       // Tampilkan confirmMenu, namun sembunyikan tombol AttackConfirm dan Confirm
@@ -71,9 +72,20 @@ export function setupActionMenu(game) {
     }
   });
 
-  // Tombol Magic (placeholder)
+  // Tombol Magic: serupa dengan Attack tetapi menandai tipe magic
   document.getElementById('btnMagic').addEventListener('click', () => {
-    alert('Magic action placeholder');
+    if (game.battle.selectedHero && !game.battle.selectedHero.actionTaken) {
+      const hero = game.battle.selectedHero;
+      game.attackMode = true;
+      game.attackType = 'magic';
+      game.battle.actionMode = 'selected';
+      actionMenu.style.display = 'none';
+      confirmMenu.style.display = 'block';
+      btnAttackConfirm.style.display = 'none';
+      btnConfirm.style.display = 'none';
+      btnCancel.style.display = 'inline-block';
+      updateProfileStatus(hero);
+    }
   });
 
   // Tombol Confirm: Finalisasi perpindahan (mode move)
@@ -122,6 +134,7 @@ export function setupActionMenu(game) {
       // Jika di fase attack (tanpa pending move), batalkan attack mode
       confirmMenu.style.display = 'none';
       game.attackMode = false;
+      game.attackType = null;
       game.battle.actionMode = 'selected';
       // Tampilkan kembali actionMenu dengan tombol Attack dan Wait (sesuai kebutuhan)
       actionMenu.style.display = 'block';


### PR DESCRIPTION
## Summary
- add `heroAttack` to Battle for applying damage
- track `attackType` on Game
- enable Attack and Magic modes through UI
- handle canceling and executing attack in input events

## Testing
- `node -e "require('./js/game.js');require('./js/ui.js');require('./js/input.js');require('./js/battle.js');"`

------
https://chatgpt.com/codex/tasks/task_e_686d22c8a31483289ed6d37232ac0258